### PR TITLE
common expand_path

### DIFF
--- a/dltranz/scenario_cls_tools.py
+++ b/dltranz/scenario_cls_tools.py
@@ -2,6 +2,7 @@ import logging
 import os
 from collections import namedtuple
 from functools import reduce
+from glob import glob
 from multiprocessing.pool import Pool
 from operator import iadd
 
@@ -225,3 +226,14 @@ class WPool:
             return self.pool.imap_unordered(func, iterable)
         else:
             return reduce(iadd, map(func, iterable))
+
+
+def expand_path(data_path, wc_paths):
+    data_path = os.path.join(data_path, '')  # ensure `/` at the end
+
+    embedding_file_names = []
+    for path in wc_paths:
+        for n_path in glob(data_path + path):
+            embedding_file_names.append(n_path[len(data_path):])
+    logger.info(f'Found {len(embedding_file_names)} embedding files: [{embedding_file_names}]')
+    return embedding_file_names

--- a/experiments/scenario_age_pred/scenario_age_pred/compare_approaches.py
+++ b/experiments/scenario_age_pred/scenario_age_pred/compare_approaches.py
@@ -45,10 +45,11 @@ def get_scores(args):
 def main(conf):
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)-7s %(funcName)-20s   : %(message)s')
 
+    embedding_file_names = sct.expand_path(conf['data_path'], conf['embedding_file_names'])
     approaches_to_train = {
         **{
             f"embeds: {file_name}": {'metric_learning_embedding_name': file_name}
-            for file_name in conf['embedding_file_names']
+            for file_name in embedding_file_names
         },
     }
     if conf['add_baselines']:
@@ -60,7 +61,7 @@ def main(conf):
         approaches_to_train.update({
             f"embeds: {file_name} and baseline": {
                 'metric_learning_embedding_name': file_name, 'use_client_agg': True, 'use_small_group_stat': True}
-            for file_name in conf['embedding_file_names']
+            for file_name in embedding_file_names
         })
 
     approaches_to_score = {

--- a/experiments/scenario_bowl2019/scenario_bowl2019/compare_approaches.py
+++ b/experiments/scenario_bowl2019/scenario_bowl2019/compare_approaches.py
@@ -47,10 +47,11 @@ def get_scores(args):
 def main(conf):
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)-7s %(funcName)-20s   : %(message)s')
 
+    embedding_file_names = sct.expand_path(conf['data_path'], conf['embedding_file_names'])
     approaches_to_train = {
         **{
             f"embeds: {file_name}": {'metric_learning_embedding_name': file_name}
-            for file_name in conf['embedding_file_names']
+            for file_name in embedding_file_names
         },
     }
     if conf['add_baselines']:
@@ -62,7 +63,7 @@ def main(conf):
         approaches_to_train.update({
             f"embeds: {file_name} and baseline": {
                 'metric_learning_embedding_name': file_name, 'use_handcrafted_features': True}
-            for file_name in conf['embedding_file_names']
+            for file_name in embedding_file_names
         })
 
     approaches_to_score = {

--- a/experiments/scenario_gender/scenario_gender/compare_approaches.py
+++ b/experiments/scenario_gender/scenario_gender/compare_approaches.py
@@ -42,10 +42,11 @@ def get_scores(args):
 def main(conf):
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)-7s %(funcName)-20s   : %(message)s')
 
+    embedding_file_names = sct.expand_path(conf['data_path'], conf['embedding_file_names'])
     approaches_to_train = {
         **{
             f"embeds: {file_name}": {'metric_learning_embedding_name': file_name}
-            for file_name in conf['embedding_file_names']
+            for file_name in embedding_file_names
         },
     }
     if conf['add_baselines']:
@@ -59,7 +60,7 @@ def main(conf):
                 'metric_learning_embedding_name': file_name,
                 'use_client_agg': True, 'use_mcc_code_stat': True, 'use_tr_type_stat': True,
             }
-            for file_name in conf['embedding_file_names']
+            for file_name in embedding_file_names
         })
 
     approaches_to_score = {

--- a/experiments/scenario_malware/scenario_malware/compare_approaches.py
+++ b/experiments/scenario_malware/scenario_malware/compare_approaches.py
@@ -46,21 +46,10 @@ def get_scores(args):
     return result
 
 
-def expand_path(data_path, wc_paths):
-    data_path = os.path.join(data_path, '')  # ensure `/` at the end
-
-    embedding_file_names = []
-    for path in wc_paths:
-        for n_path in glob(data_path + path):
-            embedding_file_names.append(n_path[len(data_path):])
-    logger.info(f'Found {len(embedding_file_names)} embedding files: [{embedding_file_names}]')
-    return embedding_file_names
-
-
 def main(conf):
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)-7s %(funcName)-20s   : %(message)s')
 
-    embedding_file_names = expand_path(conf['data_path'], conf['embedding_file_names'])
+    embedding_file_names = sct.expand_path(conf['data_path'], conf['embedding_file_names'])
     approaches_to_train = {
         **{
             f"embeds: {file_name}": {'metric_learning_embedding_name': file_name}

--- a/experiments/scenario_x5/scenario_x5/compare_approaches.py
+++ b/experiments/scenario_x5/scenario_x5/compare_approaches.py
@@ -1,12 +1,10 @@
 import logging
-import os
 from functools import partial, reduce
 from operator import iadd
 
 import numpy as np
 import pandas as pd
-from glob import glob
-from sklearn.metrics import roc_auc_score, make_scorer, accuracy_score
+from sklearn.metrics import make_scorer, accuracy_score
 
 import dltranz.scenario_cls_tools as sct
 from scenario_x5.const import (
@@ -63,21 +61,10 @@ def get_scores(args):
     return result
 
 
-def expand_path(data_path, wc_paths):
-    data_path = os.path.join(data_path, '')  # ensure `/` at the end
-
-    embedding_file_names = []
-    for path in wc_paths:
-        for n_path in glob(data_path + path):
-            embedding_file_names.append(n_path[len(data_path):])
-    logger.info(f'Found {len(embedding_file_names)} embedding files: [{embedding_file_names}]')
-    return embedding_file_names
-
-
 def main(conf):
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)-7s %(funcName)-20s   : %(message)s')
 
-    embedding_file_names = expand_path(conf['data_path'], conf['embedding_file_names'])
+    embedding_file_names = sct.expand_path(conf['data_path'], conf['embedding_file_names'])
     approaches_to_train = {
         **{
             f"embeds: {file_name}": {'metric_learning_embedding_name': file_name}


### PR DESCRIPTION
Wildcard symbols allowed in embedding names in compare approaches.
Before:
```
python -m scenario_<> compare_approaches --embedding_file_names \
    "emb__hidden_size__hs_1600.pickle" \
    "emb__hidden_size__hs_0800.pickle"  \
    "emb__hidden_size__hs_0480.pickle"  \
    "emb__hidden_size__hs_0160.pickle"  \
    "emb__hidden_size__hs_0064.pickle"
```

Now:
```
python -m scenario_<> compare_approaches --embedding_file_names \
    "emb__hidden_size__hs_*.pickle" 
```

@dllllb , @OvsovNikita , FYI
